### PR TITLE
Simplify playing around with the setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+ports:
+- port: 3000
+  onOpen: open-preview
+tasks:
+- init: npm install
+  command: npx tsc && npm start

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Have fun! It's just code. If something goes horrifically wrong, you can always c
 3. `npm start` will start your server.
 4. <kbd>Ctrl</kbd>+<kbd>c</kbd> to shut off the server.
 
+To play around with the setup you can open it in Gitpod (requires OAuth with GitHub).
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#https://github.com/aleph-naught2tog/ts_without_dependencies)
+
 ### Typescript
 
 Your Typescript files should go in the `src` folder. Everything else should be in the `public` folder -- HTML, images, CSS, etc.


### PR DESCRIPTION
This PR adds a gitpod config and button, that allows opening a dev environment for the setup in the browser. It will start a small container with a shell in the cloud and provide a VS Code based IDE running in the browser. 

I configured it to automatically install dependencies, run tsc and start the server. Also, the button will open the application in the preview.

Here is a preview of what it would like:
<img width="2012" alt="screen shot 2019-01-06 at 10 48 18" src="https://user-images.githubusercontent.com/3082655/50734637-110dc500-11a2-11e9-8f30-47ecdcf3e785.png">

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/05730ab7-12c6-4a44-937f-c609234ef78e)